### PR TITLE
Rename `names` to `subMap`, and add new function `names`

### DIFF
--- a/src/Graphics/Rendering/Diagrams.hs
+++ b/src/Graphics/Rendering/Diagrams.hs
@@ -113,7 +113,7 @@ module Graphics.Rendering.Diagrams
 
        , QDiagram, mkQD, Diagram
        , prims
-       , envelope, trace, names, query, sample
+       , envelope, trace, subMap, names, query, sample
        , value, resetValue, clearValue
 
        , named, nameSub, namePoint


### PR DESCRIPTION
`names` is now a poor name for something which returns a mapping from names to subdiagrams.  Also, the old version of `names` used to have a result with a `Show` instance, but a `SubMap` really can't have one.  This patch renames `names` to `subMap`, and creates a new function `names` which returns a list of names paired with their associated locations (which can be `Show`n).
