### PR TITLE
make SubMaps deletable, and add a new function 'localize' for hiding/deleting names

### DIFF
--- a/src/Diagrams/Core.hs
+++ b/src/Diagrams/Core.hs
@@ -120,6 +120,7 @@ module Diagrams.Core
        , withName
        , withNameAll
        , withNames
+       , localize
 
        , freeze, setEnvelope, setTrace
 


### PR DESCRIPTION
This makes recursive constructions using names possible (i.e. using the same names at each level, then hiding them so they don't interfere with any of the levels above).
