### PR TITLE
onBasis gets the matrix equivalent of the Transformation

### DIFF
--- a/src/Diagrams/Core/Transform.hs
+++ b/src/Diagrams/Core/Transform.hs
@@ -182,7 +182,7 @@ fromLinear :: AdditiveGroup v => (v :-: v) -> (v :-: v) -> Transformation v
 fromLinear l1 l2 = Transformation l1 l2 zeroV
 
 -- | Get the matrix equivalent of the linear transform,
---   (as a list of rows) and the translation vector.  This
+--   (as a list of columns) and the translation vector.  This
 --   is mostly useful for implementing backends.
 onBasis :: forall v. HasLinearMap v => Transformation v -> ([v], v)
 onBasis t = (vmat, tr)


### PR DESCRIPTION
closes #22

This is a helper function to avoid writing the same code for every backend and every vector space.  It makes a couple of assumptions about HasBasis implementations, which are true of the instances in Data.Basis and Diagrams, but might not be true in general:
- that decompose returns all basis functions, not just those with non-zero coefficients
- that the basis functions are returned in a meaningful order

The new function onBasis returns a list of vectors.  The length of the list should be the same as the number of components in each vector, but that is not explicit in the type.  The specialized version in TwoD.Transform returns a pair of vectors, instead of a list.  (See next pull request, against diagrams-lib.)

This code ended up being identical to that in Diagrams.Backend.Show renderTransf.  The diagrams-lib pull request modifies that function to use the new onBasis function.
