### PR TITLE
Add lookupName function.

### DIFF
--- a/src/Diagrams/Core/Types.hs
+++ b/src/Diagrams/Core/Types.hs
@@ -59,6 +59,7 @@ module Diagrams.Core.Types
          -- ** Modifying diagrams
          -- *** Names
        , nameSub
+       , lookupName
        , withName
        , withNameAll
        , withNames
@@ -276,6 +277,12 @@ nameSub :: ( IsName n
         => (QDiagram b v m -> Subdiagram b v m) -> n -> QDiagram b v m -> QDiagram b v m
 nameSub s n d = over QD (D.applyUpre . inj . toDeletable $ fromNames [(n,s d)]) d
 
+-- | Lookup the most recent diagram associated with (some
+--   qualification of) the given name.
+lookupName :: IsName n
+           => n -> QDiagram b v m -> Maybe (Subdiagram b v m)
+lookupName n d = lookupSub (toName n) (subMap d) >>= listToMaybe
+
 -- | Given a name and a diagram transformation indexed by a
 --   subdiagram, perform the transformation using the most recent
 --   subdiagram associated with (some qualification of) the name,
@@ -283,7 +290,7 @@ nameSub s n d = over QD (D.applyUpre . inj . toDeletable $ fromNames [(n,s d)]) 
 withName :: IsName n
          => n -> (Subdiagram b v m -> QDiagram b v m -> QDiagram b v m)
          -> QDiagram b v m -> QDiagram b v m
-withName n f d = maybe id f (lookupSub (toName n) (subMap d) >>= listToMaybe) d
+withName n f d = maybe id f (lookupName n d) d
 
 -- | Given a name and a diagram transformation indexed by a list of
 --   subdiagrams, perform the transformation using the


### PR DESCRIPTION
Example of use:

``` haskell
-- If a straight line was drawn between two named subdiagrams, but
-- stopped at the edge of each subdiagram, where would the endpoints be?
connectionPoints n1 n2 d = do
  b1 <- lookupName n1 d
  b2 <- lookupName n2 d
  let v = location b2 .-. location b1
      midpoint = location b1 .+^ (v/2)
      p1 = fromJust $ traceP midpoint (-v) b1
      p2 = fromJust $ traceP midpoint v b2
  return (p1,p2)
```

(We also need to export it in diagrams-lib.)
