### PR TITLE
Bump lens upper version bounds

### DIFF
--- a/diagrams-core.cabal
+++ b/diagrams-core.cabal
@@ -42,7 +42,7 @@ Library
                        semigroups >= 0.8.4 && < 0.16,
                        monoid-extras >= 0.3 && < 0.4,
                        dual-tree >= 0.2 && < 0.3,
-                       lens >= 4.0 && < 4.5,
+                       lens >= 4.0 && < 4.6,
                        linear >= 1.10 && < 1.11,
                        adjunctions >= 4.0 && < 5.0,
                        distributive >=0.2.2 && < 1.0,


### PR DESCRIPTION
Allow `diagrams-core` to use the latest version of `lens` (4.5).
