### PR TITLE
Bump linear upper version bounds

### DIFF
--- a/diagrams-core.cabal
+++ b/diagrams-core.cabal
@@ -43,7 +43,7 @@ Library
                        monoid-extras >= 0.3 && < 0.4,
                        dual-tree >= 0.2 && < 0.3,
                        lens >= 4.0 && < 4.6,
-                       linear >= 1.10 && < 1.11,
+                       linear >= 1.10 && < 1.12,
                        adjunctions >= 4.0 && < 5.0,
                        distributive >=0.2.2 && < 1.0,
                        mtl


### PR DESCRIPTION
Yet another simple version bump, this time for `linear-1.11`.
