### PR TITLE
Style lenses

### DIFF
--- a/src/Diagrams/Core.hs
+++ b/src/Diagrams/Core.hs
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Core
--- Copyright   :  (c) 2011 diagrams-core team (see LICENSE)
+-- Copyright   :  (c) 2011-2015 diagrams-core team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --

--- a/src/Diagrams/Core.hs
+++ b/src/Diagrams/Core.hs
@@ -22,7 +22,7 @@
 -- The diagrams library relies heavily on custom types and classes. Many
 -- of the relevant definitions are in the "Diagrams.Core.Types" module.
 -- Indeed the definition of the diagram type @QDiagram@ is contained in:
--- 'Diagrams.Core.Types.QDiagram'. 
+-- 'Diagrams.Core.Types.QDiagram'.
 --
 -- The best place to start when learning
 -- about diagrams\' types is the user manual:
@@ -32,11 +32,11 @@
 --
 -- * "Diagrams.Core.Types"
 --
---     * @Annotation@, 
+--     * @Annotation@,
 --     * @UpAnnots b v m@, @DownAnnots v@,
 --     * @QDiaLeaf b v m@, @Measure v@,
 --     * @Subdiagram b v m@,  @SubMap b v m@,
---     * @Prim b v@, @Backend b v@, 
+--     * @Prim b v@, @Backend b v@,
 --     * @DNode b v a@, @DTree b v a@,
 --     * @RNode b v a@, @RTree b v a@,
 --     * @NullBackend@, @Renderable t b@,
@@ -149,10 +149,11 @@ module Diagrams.Core
          -- * Attributes and styles
 
        , AttributeClass
-       , Attribute, mkAttr, mkTAttr, unwrapAttr
+       , Attribute (..)
 
        , Style, HasStyle(..)
-       , getAttr, combineAttr
+       , getAttr
+       , atAttr, atMAttr, atTAttr
        , applyAttr, applyMAttr, applyTAttr
 
          -- * Envelopes

--- a/src/Diagrams/Core/Compile.hs
+++ b/src/Diagrams/Core/Compile.hs
@@ -7,7 +7,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Core.Compile
--- Copyright   :  (c) 2013 diagrams-core team (see LICENSE)
+-- Copyright   :  (c) 2013-2015 diagrams-core team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
@@ -63,7 +63,8 @@ uncurry3 :: (a -> b -> c -> r) -> (a, b, c) -> r
 uncurry3 f (x, y, z) = f x y z
 
 -- | Convert a @QDiagram@ into a raw tree.
-toDTree :: (HasLinearMap v, Floating n, Typeable n) => n -> n -> QDiagram b v n m -> Maybe (DTree b v n Annotation)
+toDTree :: (HasLinearMap v, Floating n, Typeable n)
+        => n -> n -> QDiagram b v n m -> Maybe (DTree b v n Annotation)
 toDTree g n (QD qd)
   = foldDUAL
 

--- a/src/Diagrams/Core/Query.hs
+++ b/src/Diagrams/Core/Query.hs
@@ -5,7 +5,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Core.Query
--- Copyright   :  (c) 2011 diagrams-core team (see LICENSE)
+-- Copyright   :  (c) 2011-2015 diagrams-core team (see LICENSE)
 -- License     :  BSD-style (see LICENSE)
 -- Maintainer  :  diagrams-discuss@googlegroups.com
 --
@@ -15,9 +15,8 @@
 -----------------------------------------------------------------------------
 
 module Diagrams.Core.Query
-       ( Query (Query)
-       , runQuery
-       ) where
+  ( Query (..)
+  ) where
 
 import           Control.Applicative
 import           Control.Lens            (Rewrapped, Wrapped (..), iso)
@@ -44,7 +43,7 @@ newtype Query v n m = Query { runQuery :: Point v n -> m }
   deriving (Functor, Applicative, Semigroup, Monoid)
 
 instance Wrapped (Query v n m) where
-  type Unwrapped (Query v n m) = (Point v n -> m)
+  type Unwrapped (Query v n m) = Point v n -> m
   _Wrapped' = iso runQuery Query
 
 instance Rewrapped (Query v a m) (Query v' a' m')

--- a/src/Diagrams/Core/Style.hs
+++ b/src/Diagrams/Core/Style.hs
@@ -66,10 +66,10 @@ module Diagrams.Core.Style
 
 import           Control.Applicative
 import           Control.Arrow           ((***))
-import           Control.Lens            hiding (Action, transform)
+import           Control.Lens            hiding (transform)
 import qualified Data.HashMap.Strict     as HM
 import qualified Data.Map                as M
-import           Data.Monoid.Action
+import           Data.Monoid.Action      as A
 import           Data.Semigroup
 import qualified Data.Set                as S
 import           Data.Typeable
@@ -240,7 +240,7 @@ instance (Additive v, Traversable v, Floating n) => Transformable (Style v n) wh
   transform t = over each (transform t)
 
 -- | Styles have no action on other monoids.
-instance Action (Style v n) m
+instance A.Action (Style v n) m
 
 -- making styles -------------------------------------------------------
 

--- a/src/Diagrams/Core/Transform.hs
+++ b/src/Diagrams/Core/Transform.hs
@@ -309,15 +309,10 @@ Proofs for the specified properties:
 --   help shorten some of the ridiculously long constraint sets.
 class (HasBasis v, Traversable v) => HasLinearMap v
 instance (HasBasis v, Traversable v) => HasLinearMap v
--- Most (if not all) of the functions in linear that use Applicative could be
--- defined in terms of Additive. Ideally we'd only use Additive but for now
--- just stick both in a class.
 
 -- | An 'Additive' vector space whose representation is made up of basis elements.
 class (Additive v, Representable v, Rep v ~ E v) => HasBasis v
 instance (Additive v, Representable v, Rep v ~ E v) => HasBasis v
-
-
 
 -- | Type class for things @t@ which can be transformed.
 class Transformable t where

--- a/src/Diagrams/Core/Types.hs
+++ b/src/Diagrams/Core/Types.hs
@@ -368,9 +368,9 @@ setTrace :: forall b v n m. ( OrderedField n, Metric v
                             , Semigroup m)
          => Trace v n -> QDiagram b v n m -> QDiagram b v n m
 setTrace t = over _Wrapped' ( D.applyUpre (inj . toDeletable $ t)
-                         . D.applyUpre (inj (deleteL :: Deletable (Trace v n)))
-                         . D.applyUpost (inj (deleteR :: Deletable (Trace v n)))
-                       )
+                            . D.applyUpre (inj (deleteL :: Deletable (Trace v n)))
+                            . D.applyUpost (inj (deleteR :: Deletable (Trace v n)))
+                            )
 
 -- | Lens onto the 'SubMap' of a 'QDiagram' (/i.e./ an association from
 --   names to subdiagrams).


### PR DESCRIPTION
Not ready to merge: `diagrams-lib` needs to make a few changes before merging.

This adds lenses for `Style`s onto attributes, and prisms for `Prim` and `RNode`. I've also removed some unused functions.

The lenses provide valid lenses onto the attributes of a style. Even though you can't traverse over the styles of a diagram yet they're useful for things like `ArrowOpts` (I also deal with them a lot in [plots](http://github.com/cchalmers/plots)) where you deal with styles explicitly. The lookup is determined by the type of the target. It's possible to specialise these lenses for particular attributes:

``` haskell
_LineJoinA :: Lens' (Style v n) (Maybe LineJoinA)
_LineJoinA = atAttr
```

Another useful trick is using the `Wrapped` instance of attributes to have a lens to the direct value:

``` haskell
sty & _LineJoin . mapping _Wrapped' ?~ LineCapButt
```

If an attribute has a default and we can check equality for this default, we can go further by using a `non` or `anon` `Iso`:

``` haskell
_LineJoin :: Lens' (Style v n) LineJoin
_LineJoin = _LineJoinA . mapping _Wrapped . non def
```

This is because having no entry in the style is the same as using the default:

``` haskell
> (mempty :: Style V2 Double) ^. _LineJoin
LineJoinMiter
```

I haven't implemented this in diagrams-lib yet. Is it something we'd want for all attributes? I'm not sure about naming conventions.