### PR TITLE
update for GHC-7.10, -Wall

### DIFF
--- a/src/Diagrams/Core/Names.hs
+++ b/src/Diagrams/Core/Names.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTs                      #-}

--- a/src/Diagrams/Core/Names.hs
+++ b/src/Diagrams/Core/Names.hs
@@ -1,11 +1,12 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE OverlappingInstances       #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeSynonymInstances       #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Core.Names

--- a/src/Diagrams/Core/Names.hs
+++ b/src/Diagrams/Core/Names.hs
@@ -80,7 +80,6 @@ instance IsName Int
 instance IsName Float
 instance IsName Double
 instance IsName Integer
-instance IsName String
 instance IsName a => IsName [a]
 instance (IsName a, IsName b) => IsName (a,b)
 instance (IsName a, IsName b, IsName c) => IsName (a,b,c)

--- a/src/Diagrams/Core/Query.hs
+++ b/src/Diagrams/Core/Query.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Core.Query
@@ -57,4 +58,3 @@ instance (Additive v, Num n) => HasOrigin (Query v n m) where
 
 instance (Additive v, Num n) => Transformable (Query v n m) where
   transform t (Query f) = Query $ f . papply (inv t)
-

--- a/src/Diagrams/Core/Style.hs
+++ b/src/Diagrams/Core/Style.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE LambdaCase            #-}
-
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Core.Style

--- a/src/Diagrams/Core/Transform.hs
+++ b/src/Diagrams/Core/Transform.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE TypeSynonymInstances       #-}
 {-# LANGUAGE UndecidableInstances       #-}
-
+{-# OPTIONS_GHC -fno-warn-unused-imports       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Diagrams.Core.Transform


### PR DESCRIPTION
Most of Foldable & Traversable are now in Prelude, so importing these
libraries is redundant.  I've just disabled those warnings.