### PR TITLE
Queries

### DIFF
--- a/diagrams-core.cabal
+++ b/diagrams-core.cabal
@@ -46,6 +46,7 @@ Library
                        linear >= 1.11.3 && < 1.21,
                        adjunctions >= 4.0 && < 5.0,
                        distributive >=0.2.2 && < 1.0,
+                       profunctors >= 5.0 && < 6.0,
                        mtl
   hs-source-dirs:      src
 

--- a/src/Diagrams/Core.hs
+++ b/src/Diagrams/Core.hs
@@ -194,8 +194,7 @@ module Diagrams.Core
          -- * Diagrams
 
        , QDiagram, Diagram, mkQD, pointDiagram
-       , envelope, trace, subMap, names, query, sample
-       , value, resetValue, clearValue
+       , envelope, trace, subMap, names, query
 
        , nameSub
        , withName

--- a/src/Diagrams/Core/Query.hs
+++ b/src/Diagrams/Core/Query.hs
@@ -20,8 +20,14 @@ module Diagrams.Core.Query
   ) where
 
 import           Control.Applicative
-import           Control.Lens            (Rewrapped, Wrapped (..), iso)
+import           Control.Lens
 import           Data.Semigroup
+import           Data.Distributive
+import           Data.Functor.Rep
+import           Data.Profunctor
+import           Data.Profunctor.Sieve
+import           Data.Profunctor.Closed
+import qualified Data.Profunctor.Rep    as P
 
 import           Linear.Affine
 import           Linear.Vector
@@ -30,18 +36,51 @@ import           Diagrams.Core.HasOrigin
 import           Diagrams.Core.Transform
 import           Diagrams.Core.V
 
-------------------------------------------------------------
---  Queries  -----------------------------------------------
-------------------------------------------------------------
+------------------------------------------------------------------------
+-- Queries
+------------------------------------------------------------------------
 
 -- | A query is a function that maps points in a vector space to
 --   values in some monoid. Queries naturally form a monoid, with
 --   two queries being combined pointwise.
 --
 --   The idea for annotating diagrams with monoidal queries came from
---   the graphics-drawingcombinators package, <http://hackage.haskell.org/package/graphics-drawingcombinators>.
+--   the graphics-drawingcombinators package,
+--   <http://hackage.haskell.org/package/graphics-drawingcombinators>.
 newtype Query v n m = Query { runQuery :: Point v n -> m }
-  deriving (Functor, Applicative, Semigroup, Monoid)
+  deriving (Functor, Applicative, Monad, Semigroup, Monoid)
+
+instance Distributive (Query v n) where
+  distribute a = Query $ \p -> fmap (\(Query q) -> q p) a
+
+instance Representable (Query v n) where
+  type Rep (Query v n) = Point v n
+  tabulate = Query
+  index    = runQuery
+
+instance Functor v => Profunctor (Query v) where
+  lmap f (Query q) = Query $ \p -> q (fmap f p)
+  rmap = fmap
+
+instance Functor v => Cosieve (Query v) (Point v) where
+  cosieve = runQuery
+
+instance Functor v => Closed (Query v) where
+  closed (Query fab) = Query $ \fxa x -> fab (fmap ($ x) fxa)
+
+instance Functor v => Costrong (Query v) where
+  unfirst (Query f) = Query f'
+    where f' fa = b where (b, d) = f ((\a -> (a, d)) <$> fa)
+  unsecond (Query f) = Query f'
+    where f' fa = b where (d, b) = f ((,) d <$> fa)
+
+instance Functor v => P.Corepresentable (Query v) where
+  type Corep (Query v) = Point v
+  cotabulate = Query
+
+-- | Setter over the input point of a query.
+queryPoint :: Setter (Query v' n' m) (Query v n m) (Point v n) (Point v' n')
+queryPoint = sets $ \f (Query q) -> Query $ q . f
 
 instance Wrapped (Query v n m) where
   type Unwrapped (Query v n m) = Point v n -> m
@@ -53,7 +92,8 @@ type instance V (Query v n m) = v
 type instance N (Query v n m) = n
 
 instance (Additive v, Num n) => HasOrigin (Query v n m) where
-  moveOriginTo (P u) (Query f) = Query $ \p -> f (p .+^ u)
+  moveOriginTo (P u) = queryPoint %~ (.+^ u)
 
 instance (Additive v, Num n) => Transformable (Query v n m) where
-  transform t (Query f) = Query $ f . papply (inv t)
+  transform t = queryPoint %~ papply (inv t)
+

--- a/src/Diagrams/Core/Types.hs
+++ b/src/Diagrams/Core/Types.hs
@@ -61,8 +61,7 @@ module Diagrams.Core.Types
        , mkQD, mkQD', pointDiagram
 
          -- ** Extracting information
-       , envelope, trace, subMap, names, query, sample
-       , value, resetValue, clearValue
+       , envelope, trace, subMap, names, query
 
          -- ** Combining diagrams
 
@@ -450,29 +449,6 @@ localize = over _Wrapped' ( D.applyUpre  (inj (deleteL :: Deletable (SubMap b v 
 -- | Get the query function associated with a diagram.
 query :: Monoid m => QDiagram b v n m -> Query v n m
 query = getU' . view _Wrapped'
-
--- | Sample a diagram's query function at a given point.
-sample :: Monoid m => QDiagram b v n m -> Point v n -> m
-sample = runQuery . query
-
--- | Set the query value for 'True' points in a diagram (/i.e./ points
---   \"inside\" the diagram); 'False' points will be set to 'mempty'.
-value :: Monoid m => m -> QDiagram b v n Any -> QDiagram b v n m
-value m = fmap fromAny
-  where fromAny (Any True)  = m
-        fromAny (Any False) = mempty
-
--- | Reset the query values of a diagram to @True@/@False@: any values
---   equal to 'mempty' are set to 'False'; any other values are set to
---   'True'.
-resetValue :: (Eq m, Monoid m) => QDiagram b v n m -> QDiagram b v n Any
-resetValue = fmap toAny
-  where toAny m | m == mempty = Any False
-                | otherwise   = Any True
-
--- | Set all the query values of a diagram to 'False'.
-clearValue :: QDiagram b v n m -> QDiagram b v n Any
-clearValue = fmap (const (Any False))
 
 -- | Create a diagram from a single primitive, along with an envelope,
 --   trace, subdiagram map, and query function.


### PR DESCRIPTION
Should be ready to merge (with lib branch). This just adds some `Query` instances and moves query related functions from `Diagrams.Core.Types` to `Diagrams.Query` in lib.

There's also a `queryPoint` setter that I found easier to think about editing queries.