### PR TITLE
Generalise vertical- and horizontal concatenation beyond the diagrams use case

### DIFF
--- a/diagrams-core.cabal
+++ b/diagrams-core.cabal
@@ -40,6 +40,7 @@ Library
                        containers >= 0.4.2 && < 0.6,
                        unordered-containers >= 0.2 && < 0.3,
                        semigroups >= 0.8.4 && < 0.19,
+                       numbered-semigroups >= 0.1 && < 0.2,
                        monoid-extras >= 0.3 && < 0.5,
                        dual-tree >= 0.2 && < 0.3,
                        lens >= 4.0 && < 4.16,


### PR DESCRIPTION
Diagrams has a nice `Juxtaposable` class that allows composing in arbitrary direction, and that is by nature pretty specific to diagrams. But much of the work in typical applications is actually done in only two discrete directions, horizontal and vertical, and that's something which is also done in many other applications. Apart from diagrams, it's obviously relevant for document layout, but also [for matrices](http://hackage.haskell.org/package/hmatrix-0.18.1.0/docs/Numeric-LinearAlgebra-Data.html#g:12) (though, that should arguably better be expressed in [a more strongly-typed manner](http://hackage.haskell.org/package/linearmap-category-0.3.2.0/docs/Math-LinearMap-Category.html)...).

But AFAIK each of these applications, Diagrams included, has only defined operators like `===` and `|||` on an ad-hoc basis.

While [designing a CSS-grid based presentation eDSL](https://github.com/leftaroundabout/beamonad/blob/master/Presentation/Yeamer/Internal/Grid.hs), I decided to not invent that wheel yet again, and instead gave the concatenation operators a [general-purpose class](http://hackage.haskell.org/package/numbered-semigroups-0.1.0.0/docs/Data-Semigroup-Numbered.html), namely, a numbered sequence of semigroups.

I've put that in a small library just for the single class. Now I wonder if we could actually make `QDiagram` an instance of that class, and thus use the same operators both for diagrams and for other multidirectional-concatenatable stuff? This would be particularly useful for that eDSL of mine since I'd like to compose both diagrams and other content in a single file, without awkward qualified names.

I'd appreciate any opinion!