### PR TITLE
Make it build with ghc-9.8

### DIFF
--- a/diagrams-core.cabal
+++ b/diagrams-core.cabal
@@ -37,7 +37,7 @@ Library
                        Diagrams.Core.V
 
   Build-depends:       base >= 4.11 && < 4.20,
-                       containers >= 0.4.2 && < 0.7,
+                       containers >= 0.4.2 && < 0.8,
                        unordered-containers >= 0.2 && < 0.3,
                        semigroups >= 0.8.4 && < 0.21,
                        monoid-extras >= 0.6 && < 0.7,


### PR DESCRIPTION
There are some still some compiler warnings but it builds with just some dependency bumps.

This could be fixed on Hackage with just a metadata edit.